### PR TITLE
fix(ts): types near built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "gjuchault/typescript-library-starter",
   "type": "module",
   "exports": "./build/index.js",
-  "types": "./build/src/index.d.ts",
+  "types": "./build/index.d.ts",
   "license": "MIT",
   "engines": {
     "node": "^18.15.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2022",
     "moduleResolution": "nodenext",
 
-    "rootDir": "./",
+    "rootDir": "./src",
     "outDir": "build",
 
     "strict": true,


### PR DESCRIPTION
Avoids `There are types at but this result could not be resolved when respecting package.json "exports". The library may need to update its package.json or typings`