### PR TITLE
semantic release github limits fix

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,6 +20,12 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failTitle": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
<img width="923" alt="Screenshot 2023-05-02 at 3 32 28 PM" src="https://user-images.githubusercontent.com/947595/235618581-f37fdab2-c6fe-48a1-8d9b-661decb25db8.png">

Implemented exactly as https://github.com/semantic-release/semantic-release/issues/2204#ref-commit-639802d 

tested afterwards, works after this change